### PR TITLE
Add inside room temperature

### DIFF
--- a/config/application-configuration.json
+++ b/config/application-configuration.json
@@ -33,7 +33,7 @@
         "engine": 5,
         "optional": true,
         "description": "The room temperature in Zone1 in degrees Celsius (°C)"
-    },    
+    },
     "OutdoorTemperature": {
         "displayOptions": {
             "label": "Outside",

--- a/config/application-configuration.json
+++ b/config/application-configuration.json
@@ -23,6 +23,17 @@
         "optional": true,
         "description": "The temperature of the cool fluid returning to the heat pump in degrees Celsius (°C)"
     },
+    "RoomTemperatureZone1": {
+        "displayOptions": {
+            "label": "Inside",
+            "color": "purple"
+        },
+        "type": "feed",
+        "autoname": "RoomTemperatureZone1",
+        "engine": 5,
+        "optional": true,
+        "description": "The room temperature in Zone1 in degrees Celsius (°C)"
+    },    
     "OutdoorTemperature": {
         "displayOptions": {
             "label": "Outside",

--- a/mmspheatpump.php
+++ b/mmspheatpump.php
@@ -168,7 +168,7 @@
                     <span class="energy-summary" data-input-config-key="HeatingEnergyConsumed1" data-output-config-key="HeatingEnergyProduced1">
                 </div>
 
-                <div data-label="Temperature" data-config-keys="FlowTemperature,ReturnTemperature,OutdoorTemperature,EffectiveTemperature,OutdoorDewPoint,TargetHCTemperatureZone1" class="chart"></div>
+                <div data-label="Temperature" data-config-keys="FlowTemperature,ReturnTemperature,OutdoorTemperature,RoomTemperatureZone1,EffectiveTemperature,OutdoorDewPoint,TargetHCTemperatureZone1" class="chart"></div>
 
 
                 <div class="section-heading">


### PR DESCRIPTION
As suggested by mjr:

https://community.openenergymonitor.org/t/heat-pump-experimentation-app-release-news/13423/19

it would be nice to include the indoor temperature too. I'm going with their suggestions for naming and coloring so this merges well with their personal setup.

The `autoname` of `RoomTemperatureZone1` will cause it to tie into the device info included along with this application, but notably a user can choose a different feed if they wish by using the application configuration icon which is a wrench in the top right corner:

![image](https://user-images.githubusercontent.com/10685068/154883066-024440b7-ba65-4d32-8a06-e5885268048b.png)
