### PR TITLE
Fixing issue #16 with status highlights

### DIFF
--- a/Lib/current-status.js
+++ b/Lib/current-status.js
@@ -78,7 +78,7 @@ async function updateToggles() {
 
         if (feedMeta) {
             const thresholdClassName = $(this).data("toggleClass")
-            if (feedMeta.value) {
+            if (feedMeta.value > 0) {
                 $(this).addClass(thresholdClassName)
             } else {
                 $(this).removeClass(thresholdClassName)


### PR DESCRIPTION
This seems to work better for me, as `"0" > 0` correctly evaluates to false.