### PR TITLE
Removing HeatPumpFrequency from Energy chart

### DIFF
--- a/mmspheatpump.php
+++ b/mmspheatpump.php
@@ -158,7 +158,7 @@
                     <span data-hide-efficiency="1" data-input-config-key="TotalEnergyConsumed1" data-output-config-key="TotalEnergyProduced1"></span>
                 </div>
 
-                <div data-label="Power" data-config-keys="solar,HeatingEnergyConsumedRate1,HeatingEnergyProducedRate1,HotWaterEnergyConsumedRate1,HotWaterEnergyProducedRate1,HeatPumpFrequency" class="chart"></div>
+                <div data-label="Power" data-config-keys="solar,HeatingEnergyConsumedRate1,HeatingEnergyProducedRate1,HotWaterEnergyConsumedRate1,HotWaterEnergyProducedRate1" class="chart"></div>
 
 
                 <div class="section-heading">Efficiency


### PR DESCRIPTION
Since changing HeatPumpFrequency to a plain percentage {[commit 1d8e7b3](https://github.com/MrTimbones/mmspheatpump/commit/1d8e7b3e0810f81fa6134a7164d3c44fd7a79d21)}, the Energy chart has lost the kW scale from the Y-axis. Therefore, I think we should remove this parameter, especially as it's not really much use any more.

Reject if you disagree...