### PR TITLE
Show pump operation time in graph summary

### DIFF
--- a/Lib/active-percent.js
+++ b/Lib/active-percent.js
@@ -1,0 +1,34 @@
+function activeAmount(activeSeries) {
+
+    const readingCount = activeSeries.length;
+    if (readingCount < 2) return 0;
+    const sum = activeSeries.reduce((partialSum, a) => partialSum + a[1], 0)
+    const proportion = sum / activeSeries.length
+    return proportion * 100
+
+}
+
+function activePercent(inputDataSeries) {
+
+    const consumed = activeAmount(inputDataSeries)
+    return consumed.toFixed(1) + "%"
+}
+
+async function updateActivePercentSummary(feedHistoryByConfigKey) {
+
+    $("[data-active-input-config-keys]").each(function () {
+        const activeConfigKeys = $(this).attr("data-active-input-config-keys").split(",").map(s => s.trim())
+
+        if (activeConfigKeys) {
+            const summaries = activeConfigKeys.map(key => {
+                const title = config.app[key].displayOptions.label
+                return title + ": " + activePercent(feedHistoryByConfigKey[key])
+            })
+            $(this).text(summaries.join(", "))
+        } else {
+            // Not enough feeds configured for this summary
+            $(this).text("")
+        }
+
+    })
+}

--- a/Lib/charts.js
+++ b/Lib/charts.js
@@ -237,6 +237,7 @@ async function loadDataAndRenderCharts(forceRefresh) {
 
     await Promise.all([
         updateWindowSummary(feedHistoryByConfigKey, timeInterval),
+        updateActivePercentSummary(feedHistoryByConfigKey),
         $(".chart").each(async function () { await drawChart($(this)) })
     ]);
 }

--- a/mmspheatpump.php
+++ b/mmspheatpump.php
@@ -192,7 +192,7 @@
 
 
                 <div class="section-heading">Pumps</div>
-
+                <span data-active-input-config-keys="WaterPump1Status,WaterPump2Status,WaterPump4Status"></span>
                 <div data-config-keys="OperationMode,WaterPump1Status,WaterPump2Status,WaterPump4Status" class="chart"></div>
 
             </div>


### PR DESCRIPTION
Shows operation proportion below heading "Pumps":

![image](https://user-images.githubusercontent.com/10685068/201537938-385d8979-1ea4-4503-ad79-f36d8c849212.png)

I did this outside the chart because I wanted the chart legend to stay focused on showing the value from the the chart line.